### PR TITLE
Remove wrong CORS rules

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -314,15 +314,6 @@ Response.prototype.status = function status(code) {
 
 
 Response.prototype.defaultResponseHeaders = function defaultHeaders(data) {
-  this.setHeader('Access-Control-Allow-Origin', '*');
-  this.setHeader('Access-Control-Allow-Headers', ALLOW_HEADERS);
-
-  if (this.methods.length)
-    this.setHeader('Access-Control-Allow-Methods', this.methods.join(', '));
-
-  this.setHeader('Access-Control-Expose-Headers',
-                 EXPOSE_HEADERS + ', ' + this.responseTimeHeader);
-
   if (!this.getHeader('Connection'))
     this.setHeader('Connection', this.keepAlive ? 'Keep-Alive' : 'close');
 


### PR DESCRIPTION
Remove wrong CORS rules so nginx can handle this.

**This fork should die ASAP, CORS rules are fixed in newer versions of restify.**
