### PR TITLE
Gracefully handling undefined obj.error

### DIFF
--- a/lib/clients/json_client.js
+++ b/lib/clients/json_client.js
@@ -65,8 +65,8 @@ JsonClient.prototype.parse = function parse(req, callback) {
       // in addition to { code: '', message: '' }.
       if (obj.code || (obj.error && obj.error.code)) {
         err = new RestError(res.statusCode,
-                            obj.code || obj.error.code,
-                            obj.message || obj.error.message);
+                            obj.code || obj.error && obj.error.code,
+                            obj.message || obj.error && obj.error.message);
       } else if (!err) {
         err = codeToHttpError(res.statusCode, obj.message || '', data);
       }


### PR DESCRIPTION
This version of restify client contains a bug if an error response contains `.code` but not `.message` and not `.error`:
```
{"error":{},"errorStack":"TypeError: Cannot read property 'message' of undefined\n 
at /.../node_modules/restify/lib/clients/json_client.js:69:53\n 
at IncomingMessage.(/.../node_modules/restify/lib/clients/string_client.js:150:16)\n 
at IncomingMessage.g (events.js:292:16)\n at emitNone (events.js:91:20)\n 
at IncomingMessage.emit (events.js:185:7)\n at endReadableNT (_stream_readable.js:974:12)\n 
at _combinedTickCallback (internal/process/next_tick.js:80:11)\n
at process._tickDomainCallback (internal/process/next_tick.js:128:9)",
"errorMessage":"Cannot read property 'message' of undefined"}
```

This hotfix checks if `obj.error` is defined before attempting to get `obj.error.code` or `obj.error.message`